### PR TITLE
Pause when timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A docker image for caching git clone/pull based on [jonasmalacofilho/git-cache-h
 
  1. git compression level turned to 9.
  2. `git gc --aggressive` run on every cached repository every night at 1:30 (can be overriden by environment variables `HOUR` and `MIN`, in 24 hour format).
- 3. After `WAIT_TIMEOUT` (default to 4 hours), no new `git gc --aggressive` process will be spawned. In the next day, gc process will start from where it was left.
+ 3. After `WAIT_TIMEOUT` (default to 4 hours, can be overloaded by environment variables), no new `git gc --aggressive` process will be spawned. In the next day, gc process will start from where it was left.
 
 *NOTE*:
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A docker image for caching git clone/pull based on [jonasmalacofilho/git-cache-h
 
  1. git compression level turned to 9.
  2. `git gc --aggressive` run on every cached repository every night at 1:30 (can be overriden by environment variables `HOUR` and `MIN`, in 24 hour format).
+ 3. After `WAIT_TIMEOUT` (default to 4 hours), no new `git gc --aggressive` process will be spawned. In the next day, gc process will start from where it was left.
 
 *NOTE*:
 

--- a/main.py
+++ b/main.py
@@ -77,7 +77,7 @@ while True:
     signal.alarm(wait_timeout)
 
     for is_finished in gc_progress:
-        if is_finished or is_timout:
+        if is_finished or is_timeout:
             # sleep for 1 min in case of the git gc command finish within one min.
             # In this case, sleep_until with return immediately and the whole gc_progress will be started again
             time.sleep(60)


### PR DESCRIPTION
Stop spawning new `git go —aggressive` process after `WAIT_TIMEOUT` (default to 4 hours, can be overloaded by environment variable).

In the next day, the gc process will start from where it left.